### PR TITLE
Pulldown Bugfix on InputOutput.h Examples and Documentation

### DIFF
--- a/Examples/ButtonTiltMovementSensor/main.cpp
+++ b/Examples/ButtonTiltMovementSensor/main.cpp
@@ -23,8 +23,8 @@ void setup() {
 	//Disable board watchdog
 	Loka::disableWatchdog();
 
-	//Set GPIO pin mode as INPUT_PULLUP
-	Loka::pinMode(IO2, INPUT_PULLUP);
+	//Set GPIO pin mode as INPUT_PULLDOWN
+	Loka::pinMode(IO2, INPUT_PULLDOWN);
 
 	//Matched the callback function with the GPIO interruption pin
 	intConnect(IO2, callback);

--- a/Examples/GroveUltrasonic/main.cpp
+++ b/Examples/GroveUltrasonic/main.cpp
@@ -40,7 +40,7 @@ int readRange(digio pin, double * range){
 ;
 
 
-	Board::pinMode(pin,INPUT_PULLUP);
+	Board::pinMode(pin,INPUT_PULLDOWN);
 
 	start=millis();
 	while(Board::digitalRead(pin)==0){ // wait for the pulse

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ The LOKA board have an Docking station that allows to connect to a set of difere
 | P6                    | D1=IO5    D2=IO6                                  | Suports Serial Port / GPIO                  |  Serial/Digital    |
 | P7                    | D1=IO6    D2=IO7                                  | Suports Serial Port Transmission / GPIO     |  Serial/Digital    |
 | P8                    | D1=IO7    D2=none                                 | GPIO                                        |  Digital           |
-| P9                    | D1=IO3    D2=IO4  (With I2C HW Pullup)            | Suports I2C                                 |  I2C               |
+| P9                    | D1=IO3    D2=IO4  (With I2C HW Pulldown)          | Suports I2C                                 |  I2C               |
 
 
 	

--- a/include/tc-rtos/drivers/InputOutput.h
+++ b/include/tc-rtos/drivers/InputOutput.h
@@ -23,7 +23,7 @@ enum {
 enum {
 	INPUT,
 	OUTPUT,
-	INPUT_PULLUP
+	INPUT_PULLDOWN
 };
 
 enum {


### PR DESCRIPTION
By Default in the CPU internal resistor is set to PULLDOWN.
Otherwise "digitalWrite(HIGH)" must be called to change it to PULLUP.